### PR TITLE
Further increase Berkeley RDI logo size to match Sky logo readability

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -988,7 +988,7 @@ $text-gray: #555;
 
       // Make Berkeley RDI logo larger for better readability
       &[alt="Berkeley RDI"] {
-        height: 90px;
+        height: 120px;
       }
     }
   }


### PR DESCRIPTION
- Increased Berkeley RDI logo height to 120px to match Sky logo text readability

